### PR TITLE
feat(gateway): 添加设备身份认证功能

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,11 @@ export interface PluginConfig {
     token: string;
     gatewayUrl: string;
     cliPath: string;
+    deviceIdentity?: {
+      id: string;
+      publicKeyPem: string;
+      privateKeyPem: string;
+    };
   };
   behavior: {
     privateChat: boolean;


### PR DESCRIPTION
## Description
                                                                                                                                                                        
  This PR fixes wss + token connection authorization for napcat-plugin-openclaw by aligning the connect handshake with Gateway requirements, while keeping              
  implementation minimal.                                                                                                                                               
                                                                                                                                                                        
  ### Problem                                                                                                                                                           
                                                                                                                                                                        
  With wss + token, the plugin only sent token-based auth and a simplified connect payload.                                                                             
  In practice, Gateway expects a signed device object in connect.params.                                                                                                
  As a result:                                                                                                                                                          

  - permission is insufficient                                                                                                                                          
  - pairing request does not appear
  - connect may fail with schema validation errors (missing device.publicKey/signature)                                                                                 
                                                                                                                                                                        
  ### What changed                                                                                                                                                      
                                                                                                                                                                        
  - Added minimal device identity support in handshake:                                                                                                                 
      - generate Ed25519 identity (id, publicKeyPem, privateKeyPem) when missing
      - send signed device fields in connect.params:                                                                                                                    
          - id                                                                                                                                                          
          - publicKey                                                                                                                                                   
          - signature                                                                                                                                                   
          - signedAt                                                                                                                                                    
          - nonce                                                                                                                                                       
  - Aligned connect protocol/scopes with working WebUI behavior:                                                                                                        
      - minProtocol: 3, maxProtocol: 3                                                                                                                                  
      - scopes: ['operator.admin', 'operator.approvals', 'operator.pairing']                                                                                            
  - Persisted device identity into existing plugin config (ctx.configPath) instead of introducing a new storage file.                                                   
                                                                                                                                                                        
  ### Scope / Minimality                                                                                                                                                
                                                                                                                                                                        
  Only touched:                                                                                                                                                         
                                                                                                                                                                        
  - src/gateway-client.ts                                                                                                                                               
  - src/index.ts                                                                                                                                                        
  - src/types.ts                                                                                                                                                        
                                                                                                                                                                        
  No unrelated refactor, no new external dependency, no new standalone persistence file.                                                                                
                                                                                                                                                                        
  ### Expected result                                                                                                                                                   
                                                                                                                                                                        
  After deploy:                                                                                                                                                         
                                                                                                                                                                        
  - wss + token connect passes with correct device payload                                                                                                              
  - pairing flow can be triggered normally                                                                                                                              
  - identity remains stable across restarts (no repeated pairing caused by random device regeneration)                                                                  
 