### PR TITLE
fix: 安全审计修复 - 13项问题一次性修复

### DIFF
--- a/src/file-fetcher.ts
+++ b/src/file-fetcher.ts
@@ -1,11 +1,11 @@
 // 文件获取器 - 通过 SSH/SCP 从 playground 获取文件
 
-import { exec, execSync } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const MARKER_FILE = '/tmp/.seren_task_marker';
 const LOCAL_FILE_DIR = '/tmp/napcat-openclaw-files';
@@ -14,10 +14,12 @@ const REMOTE_OUTPUT_DIR = '/root/.openclaw/workspace/output';
 export class FileFetcher {
   private host: string;
   private user: string;
+  private logger?: { warn?: (message: string) => void };
 
-  constructor(host: string, user: string = 'root') {
+  constructor(host: string, user: string = 'root', logger?: { warn?: (message: string) => void }) {
     this.host = host;
     this.user = user;
+    this.logger = logger;
     
     // 确保本地目录存在
     if (!fs.existsSync(LOCAL_FILE_DIR)) {
@@ -25,13 +27,36 @@ export class FileFetcher {
     }
   }
 
+  private getHostTarget(): string {
+    if (!/^[a-zA-Z0-9._-]+$/.test(this.user) || !/^[a-zA-Z0-9._:-]+$/.test(this.host)) {
+      throw new Error('invalid ssh target');
+    }
+    return `${this.user}@${this.host}`;
+  }
+
+  private validateRemotePath(remotePath: string): string {
+    const normalized = remotePath.trim();
+    if (!normalized.startsWith(`${REMOTE_OUTPUT_DIR}/`)) {
+      throw new Error(`remote path out of allowed dir: ${normalized}`);
+    }
+    if (/[\r\n\0]/.test(normalized)) {
+      throw new Error('remote path contains invalid characters');
+    }
+    return normalized;
+  }
+
   // 创建标记文件（在远程执行前调用）
   async createMarker(): Promise<void> {
     try {
-      const cmd = `ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no ${this.user}@${this.host} "touch ${MARKER_FILE}"`;
-      await execAsync(cmd);
-    } catch (e) {
-      // 静默失败，不影响主流程
+      await execFileAsync('ssh', [
+        '-o', 'ConnectTimeout=5',
+        '-o', 'StrictHostKeyChecking=no',
+        this.getHostTarget(),
+        'touch',
+        MARKER_FILE,
+      ]);
+    } catch (e: any) {
+      this.logger?.warn?.(`[OpenClaw] createMarker 失败: ${e?.message || e}`);
     }
   }
 
@@ -41,9 +66,21 @@ export class FileFetcher {
 
     try {
       // 1. 在远程查找新文件
-      const findCmd = `ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no ${this.user}@${this.host} "find ${REMOTE_OUTPUT_DIR} -type f -newer ${MARKER_FILE} 2>/dev/null"`;
-      
-      const { stdout } = await execAsync(findCmd, { timeout: 30000 });
+      const { stdout } = await execFileAsync(
+        'ssh',
+        [
+          '-o', 'ConnectTimeout=10',
+          '-o', 'StrictHostKeyChecking=no',
+          this.getHostTarget(),
+          'find',
+          REMOTE_OUTPUT_DIR,
+          '-type',
+          'f',
+          '-newer',
+          MARKER_FILE,
+        ],
+        { timeout: 30000 }
+      );
       const remoteFiles = stdout.trim().split('\n').filter(f => f.length > 0);
 
       if (remoteFiles.length === 0) {
@@ -57,24 +94,34 @@ export class FileFetcher {
       }
 
       for (const remotePath of remoteFiles) {
-        const fileName = path.basename(remotePath);
+        const safeRemotePath = this.validateRemotePath(remotePath);
+        const fileName = path.basename(safeRemotePath);
         const localPath = path.join(taskDir, fileName);
 
         try {
-          const scpCmd = `scp -o ConnectTimeout=10 -o StrictHostKeyChecking=no ${this.user}@${this.host}:"${remotePath}" "${localPath}"`;
-          await execAsync(scpCmd, { timeout: 60000 });
+          await execFileAsync(
+            'scp',
+            [
+              '-o', 'ConnectTimeout=10',
+              '-o', 'StrictHostKeyChecking=no',
+              `${this.getHostTarget()}:${safeRemotePath}`,
+              localPath,
+            ],
+            { timeout: 60000 }
+          );
 
           if (fs.existsSync(localPath)) {
             localFiles.push(localPath);
           }
-        } catch (e) {
-          // 单个文件失败继续尝试其他文件
+        } catch (e: any) {
+          this.logger?.warn?.(`[OpenClaw] SCP 拉取失败: ${safeRemotePath} - ${e?.message || e}`);
         }
       }
 
       return localFiles;
-    } catch (e) {
+    } catch (e: any) {
       // 出错时返回空数组
+      this.logger?.warn?.(`[OpenClaw] fetchNewFiles 失败: ${e?.message || e}`);
       return [];
     }
   }
@@ -99,8 +146,8 @@ export class FileFetcher {
           }
         }
       }
-    } catch (e) {
-      // 清理失败不影响主流程
+    } catch (e: any) {
+      this.logger?.warn?.(`[OpenClaw] cleanupOldFiles 失败: ${e?.message || e}`);
     }
   }
 }

--- a/src/gateway-client.ts
+++ b/src/gateway-client.ts
@@ -217,6 +217,13 @@ export class GatewayClient {
 
     this.connectPromise = new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
+        if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
+          try {
+            this.ws.close(4001, 'connect timeout');
+          } catch {
+            // ignore close errors on timeout path
+          }
+        }
         reject(new Error('connect timeout'));
         this.connectPromise = null;
       }, 15000);

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -1,4 +1,5 @@
 // 任务管理器 - 管理任务状态、限流、并发控制
+import { randomUUID } from 'crypto';
 
 export enum TaskState {
   PENDING = 'pending',
@@ -52,7 +53,7 @@ export class TaskManager {
   }
 
   private generateTaskId(): string {
-    return Math.random().toString(36).substring(2, 10);
+    return randomUUID().replace(/-/g, '').slice(0, 8);
   }
 
   private checkRateLimit(userId: number): boolean {


### PR DESCRIPTION
## 安全审计修复

### 🔴 Critical
1. **移除硬编码 token** — index.js 中的 gateway token 已替换为空字符串默认值
2. **修复 SSH 命令注入** — exec() 全部替换为 execFile()，添加输入验证（host/user/remotePath）

### 🟠 High
3. **src/ token 脱敏** — plugin_get_config 现在也会 mask token
4. **index.mjs 标记为 legacy** — 添加警告注释，明确 index.js 为规范源

### 🟡 Medium
5. **输入状态修复** — finally 块中关闭 typing 状态
6. **连接超时关闭 socket** — gateway-client 超时时显式关闭 ws
7. **重定向限制** — downloadToBuffer 最多跟 5 次
8. **异步 I/O** — 热路径 sync 操作改为 async
9. **错误可观测性** — silent catch 改为 logger.warn
10. **配置统一** — index.js 和 src/ 配置处理逻辑对齐

### 🟢 Low
11. 移除未使用的 activeTasks
12. Math.random → crypto.randomUUID
13. 日志截断用户输入至 50 字符