### PR TITLE
feat: 统一代码源 + 安全修复第二轮

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+// Standalone version - NOT used by vite build. See src/index.ts for canonical source.
 // NapCat Plugin: OpenClaw QQ Channel
 // 通过 WebSocket RPC 协议与 OpenClaw Gateway 通信
 // 支持 chat.send（gateway 自动处理斜杠命令）


### PR DESCRIPTION
## 变更概要

### 功能迁移（index.js → src/index.ts）
- ✅ 消息防抖合并（debounceMessage + debounceBuffers）
- ✅ Agent 主动推送监听（setupAgentPushListener）
- ✅ 媒体缓存落盘（saveMediaToCache + downloadToBuffer）
- ✅ 图片发送（sendImageMsg）
- ✅ 群会话模式（groupSessionMode shared/user）

### 安全修复
- ✅ CLI fallback: execAsync → execFileAsync + argv + env（消除命令注入）
- ✅ chat.send 失败时清理 chatWaiters（防内存泄漏）
- ✅ debounceMs=0 边界修复
- ✅ downloadToBuffer SSRF 防护（私网 IP + DNS 解析后校验）

### WebUI 配置面板
- ✅ buildConfigSchema 包含全部 9 个配置项
- ✅ plugin_get_config token 脱敏
- ✅ plugin_set_config 兼容扁平/dotted key

### 验证
- tsc --noEmit ✅
- vite build ✅

+401/-28 行，主要改动在 src/index.ts